### PR TITLE
Port GStreamerBridge and GStreamerCam to Nodelets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   cv_bridge
   image_transport
+  nodelet
+  pluginlib
 )
 
 #find_package(Eigen3 REQUIRED)
@@ -23,7 +25,7 @@ pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0>=1.14)
 pkg_check_modules(GSTREAMER_BASE REQUIRED gstreamer-base-1.0>=1.14)
 
 catkin_package(
-  CATKIN_DEPENDS roscpp std_msgs image_transport sensor_msgs cv_bridge
+  CATKIN_DEPENDS roscpp std_msgs image_transport sensor_msgs cv_bridge nodelet pluginlib
 )
 
 include_directories(

--- a/include/gstreamer_ros_bridge/gstreamer_bridge.hpp
+++ b/include/gstreamer_ros_bridge/gstreamer_bridge.hpp
@@ -9,6 +9,7 @@
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <nodelet/nodelet.h>
+#include <nodelet/loader.h>
 #include <cstdlib>
 
 namespace gstreamer_ros_bridge

--- a/include/gstreamer_ros_bridge/gstreamer_bridge.hpp
+++ b/include/gstreamer_ros_bridge/gstreamer_bridge.hpp
@@ -25,8 +25,6 @@ public:
     ~GStreamerRosBridge();
 
     ros::NodeHandle nh_;
-    // ros_rate for fps workaround
-    ros::Rate ros_rate_{30};
 
 private:
     virtual void onInit() override;

--- a/include/gstreamer_ros_bridge/gstreamer_bridge.hpp
+++ b/include/gstreamer_ros_bridge/gstreamer_bridge.hpp
@@ -8,20 +8,31 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/CameraInfo.h>
+#include <nodelet/nodelet.h>
 #include <cstdlib>
+
+namespace gstreamer_ros_bridge
+{
 
 /* 
     this node takes a image rostopic and pushes it through a gstreamer pipeline
 */
 
-class GStreamerRosBridge
+class GStreamerRosBridge : public nodelet::Nodelet
 {
 public:
-    GStreamerRosBridge(ros::NodeHandle &nh);
+    GStreamerRosBridge() = default;
     ~GStreamerRosBridge();
+
+    ros::NodeHandle nh_;
     // ros_rate for fps workaround
     ros::Rate ros_rate_{30};
+
 private:
+    virtual void onInit() override;
+
+    cv::Mat resizeAndPad(cv::Mat &image, int target_width, int target_height);
+
     /**
     * @brief function to recieve from ros image topic and publish to pipeline to peer 
     * @param msg - image message from ros
@@ -37,8 +48,8 @@ private:
 
     // gstreamer param member vars
     int gst_width_{640}, gst_height_{480};
-
-
 };
+
+}
 
 #endif //GSTREAMER_ROS_BRIDGE_GSTREAMER_BRIDGE_HPP

--- a/include/gstreamer_ros_bridge/gstreamer_cam.hpp
+++ b/include/gstreamer_ros_bridge/gstreamer_cam.hpp
@@ -10,23 +10,28 @@
 #include <gst/gst.h>
 #include <gst/app/gstappsink.h>
 #include <image_transport/image_transport.h>
+#include <nodelet/nodelet.h>
+
+namespace gstreamer_ros_bridge
+{
 
 /* 
     this node starts a gstreamer video feed from the camera and pushes it onto a camera topic
 */
 
-class GStreamerCam
+class GStreamerCam : public nodelet::Nodelet
 {
 public:
-    GStreamerCam(ros::NodeHandle &nh);
+    GStreamerCam();
     ~GStreamerCam();
-    void Update();
-    int GetFrameRate() const;
 
     GstElement *pipeline_;
     GstElement *appsink_;
 
 private:
+    virtual void onInit() override;
+    void Update(const ros::TimerEvent&);
+
     /**
     * @brief set cam params for camera/camera_info 
     */
@@ -47,6 +52,7 @@ private:
     image_transport::Publisher rosImagePub_;
 
     ros::NodeHandle nh_;
+    ros::Timer update_timer_;
     image_transport::ImageTransport it_;
 
     cv::Mat frame_; // published frame
@@ -56,5 +62,7 @@ private:
     std::string camera_location_, camera_format_, camera_topic_;
     int camera_width_, camera_height_, camera_fps_;
 };
+
+}
 
 #endif 

--- a/include/gstreamer_ros_bridge/gstreamer_cam.hpp
+++ b/include/gstreamer_ros_bridge/gstreamer_cam.hpp
@@ -11,6 +11,7 @@
 #include <gst/app/gstappsink.h>
 #include <image_transport/image_transport.h>
 #include <nodelet/nodelet.h>
+#include <nodelet/loader.h>
 
 namespace gstreamer_ros_bridge
 {

--- a/launch/jetson_imx219_nodelet.launch
+++ b/launch/jetson_imx219_nodelet.launch
@@ -24,9 +24,11 @@
     <arg name="bitrate" default="1200"/>
     <arg name="mtu" default="500"/>
 
+    <!-- Nodelet Manager -->
+    <node pkg="nodelet" type="nodelet" name="camera_manager" args="manager" output="screen" />
    
     <!-- Include Camera Node -->
-    <node pkg="gstreamer_ros_bridge" type="gstreamer_cam_node" name="gstreamer_cam_node" output="screen">
+    <node pkg="nodelet" type="nodelet" name="gstreamer_cam_node" args="load gstreamer_ros_bridge/GStreamerCam camera_manager" output="screen" >
         <param name="camera_location" value="$(arg camera_location)" />
         <param name="camera_width" value="$(arg camera_width)" />
         <param name="camera_height" value="$(arg camera_height)" />
@@ -43,7 +45,7 @@
     </node>
 
     <!-- Include GStreamer Bridge - Comment to only publish image to local ROS topics -->
-    <node pkg="gstreamer_ros_bridge" type="gstreamer_bridge_node" name="gstreamer_bridge_node" output="screen">
+    <node pkg="nodelet" type="nodelet" name="gstreamer_bridge_node" args="load gstreamer_ros_bridge/GStreamerRosBridge camera_manager" output="screen">
         <!--params for gstreamer pipeline to peer (over udp)-->
         <param name="bitrate" value="$(arg bitrate)"/>
         <param name="mtu" value="$(arg mtu)"/>

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,0 +1,8 @@
+<library path="lib/libgstreamer_ros_bridge">
+  <!-- bridge -->
+  <class name="gstreamer_ros_bridge/GStreamerRosBridge" type="gstreamer_ros_bridge::GStreamerRosBridge" base_class_type="nodelet::Nodelet">
+    <description>
+      A Nodelet for forwarding ros images to a Gstreamer remote client
+    </description>
+  </class>
+</library>

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,4 +1,10 @@
 <library path="lib/libgstreamer_ros_bridge">
+  <!-- camera -->
+  <class name="gstreamer_ros_bridge/GStreamerCam" type="gstreamer_ros_bridge::GStreamerCam" base_class_type="nodelet::Nodelet">
+    <description>
+    A Nodelet for publishing camera images onto ROS
+    </description>
+  </class>
   <!-- bridge -->
   <class name="gstreamer_ros_bridge/GStreamerRosBridge" type="gstreamer_ros_bridge::GStreamerRosBridge" base_class_type="nodelet::Nodelet">
     <description>

--- a/package.xml
+++ b/package.xml
@@ -61,10 +61,12 @@
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <depend>nodelet</depend>
+  <depend>pluginlib</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
-
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>
 </package>

--- a/src/gstreamer_bridge.cpp
+++ b/src/gstreamer_bridge.cpp
@@ -68,7 +68,7 @@ void GStreamerRosBridge::onInit()
     std::string gs_port = "5602";
     nh_.getParam("port", gs_port);
 
-    int gst_fps, bitrate, mtu;
+    int gst_fps = 30, bitrate = 1200, mtu = 500;
     nh_.getParam("gst_width", gst_width_);
     nh_.getParam("gst_height", gst_height_);
     nh_.getParam("gst_fps", gst_fps);

--- a/src/gstreamer_bridge.cpp
+++ b/src/gstreamer_bridge.cpp
@@ -74,7 +74,6 @@ void GStreamerRosBridge::onInit()
     nh_.getParam("gst_fps", gst_fps);
     nh_.getParam("bitrate", bitrate);
     nh_.getParam("mtu", mtu);
-    ros_rate_ = ros::Rate(gst_fps);  // update ros rate
 
     setenv("GST_DEBUG", "3", 1);
     

--- a/src/gstreamer_bridge.cpp
+++ b/src/gstreamer_bridge.cpp
@@ -1,12 +1,19 @@
 #include "gstreamer_bridge.hpp"
 
-cv::Mat resizeAndPad(cv::Mat &image, int target_width, int target_height) {
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(gstreamer_ros_bridge::GStreamerRosBridge, nodelet::Nodelet)
+
+namespace gstreamer_ros_bridge
+{
+
+cv::Mat GStreamerRosBridge::resizeAndPad(cv::Mat &image, int target_width, int target_height) {
     if (image.empty()) {
-        ROS_ERROR("Input image is empty");
+        NODELET_ERROR("Input image is empty");
         return cv::Mat();
     }
     if (image.cols == 0 || image.rows == 0) {
-        ROS_ERROR("Image has empty rows or columns");
+        NODELET_ERROR("Image has empty rows or columns");
         return cv::Mat();
     }
 
@@ -46,19 +53,27 @@ cv::Mat resizeAndPad(cv::Mat &image, int target_width, int target_height) {
     image.release();
     return padded_image;
 }
-GStreamerRosBridge::GStreamerRosBridge(ros::NodeHandle &nh)
+
+GStreamerRosBridge::~GStreamerRosBridge()
 {
+    pipeline_.release();
+}
+
+void GStreamerRosBridge::onInit()
+{
+    nh_ = getPrivateNodeHandle();
+
     std::string gs_ip = "100.64.0.1";
-    nh.getParam("ip", gs_ip);
+    nh_.getParam("ip", gs_ip);
     std::string gs_port = "5602";
-    nh.getParam("port", gs_port);
+    nh_.getParam("port", gs_port);
 
     int gst_fps, bitrate, mtu;
-    nh.getParam("gst_width", gst_width_);
-    nh.getParam("gst_height", gst_height_);
-    nh.getParam("gst_fps", gst_fps);
-    nh.getParam("bitrate", bitrate);
-    nh.getParam("mtu", mtu);
+    nh_.getParam("gst_width", gst_width_);
+    nh_.getParam("gst_height", gst_height_);
+    nh_.getParam("gst_fps", gst_fps);
+    nh_.getParam("bitrate", bitrate);
+    nh_.getParam("mtu", mtu);
     ros_rate_ = ros::Rate(gst_fps);  // update ros rate
 
     setenv("GST_DEBUG", "3", 1);
@@ -77,33 +92,28 @@ GStreamerRosBridge::GStreamerRosBridge(ros::NodeHandle &nh)
         << " sync=false";
     
     std::string gst_topic = "/camera/image_rect";
-    nh.getParam("gst_topic", gst_topic);
+    nh_.getParam("gst_topic", gst_topic);
 
     // start the udp pipeline
     std::string gstreamer_pipeline = udpPipeline.str();
     pipeline_.open(gstreamer_pipeline, cv::CAP_GSTREAMER, 0, gst_fps, cv::Size(gst_width_, gst_height_), true);
     if (!pipeline_.isOpened())
     {
-        ROS_ERROR("Failed to open gstreamer pipeline");
+        NODELET_ERROR("Failed to open gstreamer pipeline");
         return;
     }
 
-    gsImageSub_ = nh.subscribe(gst_topic, 1, &GStreamerRosBridge::GsImageCallback, this, ros::TransportHints().tcpNoDelay());
-}
-
-GStreamerRosBridge::~GStreamerRosBridge()
-{
-    pipeline_.release();
+    gsImageSub_ = nh_.subscribe(gst_topic, 1, &GStreamerRosBridge::GsImageCallback, this, ros::TransportHints().tcpNoDelay());
 }
 
 void GStreamerRosBridge::GsImageCallback(const sensor_msgs::ImageConstPtr &msg)
 {
     if (!pipeline_.isOpened()) {
-        ROS_ERROR("GStreamer pipeline is not opened, unable to write image");
+        NODELET_ERROR("GStreamer pipeline is not opened, unable to write image");
         return;
     }
     if (!msg) {
-        ROS_ERROR("Received an empty image message.");
+        NODELET_ERROR("Received an empty image message.");
         return;
     }   
     // write to gstreamer pipeline
@@ -111,7 +121,7 @@ void GStreamerRosBridge::GsImageCallback(const sensor_msgs::ImageConstPtr &msg)
         cv_bridge::CvImageConstPtr cv_ptr = cv_bridge::toCvShare(msg, sensor_msgs::image_encodings::BGR8);
         frame_ = cv_ptr->image;
     } catch (cv_bridge::Exception &e) {
-        ROS_ERROR("cv_bridge exception: %s", e.what());
+        NODELET_ERROR("cv_bridge exception: %s", e.what());
     }
     // check if image needs to be resized
     if (frame_.cols != gst_width_ || frame_.rows != gst_height_){
@@ -121,3 +131,4 @@ void GStreamerRosBridge::GsImageCallback(const sensor_msgs::ImageConstPtr &msg)
     frame_.release();
 }
 
+}

--- a/src/gstreamer_bridge_node.cpp
+++ b/src/gstreamer_bridge_node.cpp
@@ -1,5 +1,4 @@
-#include <ros/ros.h>
-#include <nodelet/loader.h>
+#include <gstreamer_bridge.hpp>
 
 int main(int argc, char **argv)
 {

--- a/src/gstreamer_bridge_node.cpp
+++ b/src/gstreamer_bridge_node.cpp
@@ -1,17 +1,19 @@
-#include "gstreamer_bridge.hpp"
+#include <ros/ros.h>
+#include <nodelet/loader.h>
 
 int main(int argc, char **argv)
 {
     ros::init(argc, argv, "gstreamer_bridge_node");
-    ros::NodeHandle nh("~");
 
-    GStreamerRosBridge bridge(nh);
+    nodelet::Loader nodelet;
+    nodelet::M_string remap(ros::names::getRemappings());
+    nodelet::V_string nargv;
 
-    while (ros::ok())
-    {
-        ros::spinOnce();
-        bridge.ros_rate_.sleep();
-    }
+    nodelet.load(ros::this_node::getName(),
+                "gstreamer_ros_bridge/GStreamerRosBridge",
+                remap, nargv);
+
+    ros::spin();
     return 0;
 }
 

--- a/src/gstreamer_cam_node.cpp
+++ b/src/gstreamer_cam_node.cpp
@@ -1,19 +1,17 @@
-#include "gstreamer_cam.hpp"
+#include <ros/ros.h>
+#include <nodelet/loader.h>
 
 int main(int argc, char **argv)
 {
     ros::init(argc, argv, "gstreamer_cam_node");
-    ros::NodeHandle nh("~");
+    nodelet::Loader nodelet;
+    nodelet::M_string remap(ros::names::getRemappings());
+    nodelet::V_string nargv;
 
-    gst_init(&argc, &argv);
-    GStreamerCam cam(nh);
-    ros::Rate rate(cam.GetFrameRate());
+    nodelet.load(ros::this_node::getName(),
+                "gstreamer_ros_bridge/GStreamerCam",
+                remap, nargv);
 
-    while (ros::ok())
-    {
-        cam.Update();
-        ros::spinOnce();
-        rate.sleep();
-    }
+    ros::spin();
     return 0;
 }

--- a/src/gstreamer_cam_node.cpp
+++ b/src/gstreamer_cam_node.cpp
@@ -1,9 +1,9 @@
-#include <ros/ros.h>
-#include <nodelet/loader.h>
+#include <gstreamer_cam.hpp>
 
 int main(int argc, char **argv)
 {
     ros::init(argc, argv, "gstreamer_cam_node");
+    gst_init(&argc, &argv);
     nodelet::Loader nodelet;
     nodelet::M_string remap(ros::names::getRemappings());
     nodelet::V_string nargv;


### PR DESCRIPTION
This is an attempt at porting the latest code to nodelets to replace what's on the `dev/nodelets` branch.

`GStreamerBridge` has been tested and confirmed working. I haven't tested `GStreamerCam` though because it would require a custom built libcamera on the Pi, but I've removed that from the Docker image already (since SAE is using `libcamera_ros_driver` now).