### PR TITLE
Add service and param for turning stream on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This node takes a ROS topic specified by the `gst_topic` param and writes it to 
 - `gst_topic`: The topic that the pipeline should take images from. Default /camera/image_rect
 - `ip`, `port`: The Peer IP and port of the local stream.
 - `bitrate`, `mtu`: Specifies the bitrate and MTU of the GStreamer pipeline to the peer. Slower networks usually require lower bitrates so the network can keep up.
+- `stream_on`: Whether the stream is turned on initially. The stream can be turned on or off after initialization by calling the service `~set_stream_on` of type `std_msgs/SetBool`.
 
 ### `gstreamer_publisher.launch`
 

--- a/include/gstreamer_ros_bridge/gstreamer_bridge.hpp
+++ b/include/gstreamer_ros_bridge/gstreamer_bridge.hpp
@@ -8,9 +8,11 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/CameraInfo.h>
+#include <std_srvs/SetBool.h>
 #include <nodelet/nodelet.h>
 #include <nodelet/loader.h>
 #include <cstdlib>
+#include <functional>
 
 namespace gstreamer_ros_bridge
 {
@@ -32,6 +34,8 @@ private:
 
     cv::Mat resizeAndPad(cv::Mat &image, int target_width, int target_height);
 
+    bool SetStreamOnCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &resp);
+
     /**
     * @brief function to recieve from ros image topic and publish to pipeline to peer 
     * @param msg - image message from ros
@@ -40,6 +44,7 @@ private:
     void GsImageCallback(const sensor_msgs::ImageConstPtr &msg);
     
     ros::Subscriber gsImageSub_;
+    ros::ServiceServer set_stream_on_srv_;
 
     // gstreamer pipeline
     cv::VideoWriter pipeline_;
@@ -47,6 +52,8 @@ private:
 
     // gstreamer param member vars
     int gst_width_{640}, gst_height_{480};
+
+    bool stream_on_ = true;
 };
 
 }


### PR DESCRIPTION
This adds a service called `~set_stream_on` of type `std_msgs/SetBool` to the bridge node so that the stream can be turned on or off. This can be used to save data or bandwidth.

On startup it also reads the param at `~stream_on` for the initial state, so the node can start with the stream turned on or off.